### PR TITLE
Update readme with possible types

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Provide configuration options through meta tags.
 
+Every property is returned as a `string`.
+`numbers` and `boolean` must be cast in the application itself.
+
 ## Installation
 
 First you need to install the npm module:


### PR DESCRIPTION
I ran into this issue and it gave me some troubles, because even if you specify a property as `number` everything compiles but the property is a `string` in reality. There is also no error because in the runtime there is no type-safety anymore. And if you do something like:
```
// this.environment.x = '5'
let value : number = 10 + this.environment.x
console.log(value) // 105
```

So I added it to the README.

Maybe there is a way to handle different types. Because it creates some overhead every time you read the .env variable and do some calculations with it. We could for example do something like this:

```
<meta name="config" property="amount" content="" type="number" />
```
And let the default be "string" to be backwards compatible.

What do you think? Should the library handle this?